### PR TITLE
Add device ID for Adaprox Fingerbot (y6kttvd6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This integration supports Tuya devices connected via BLE.
 
-_Inspired by code of [@redphx](https://github.com/redphx/poc-tuya-ble-fingerbot)
+_Inspired by code of [@redphx](https://github.com/redphx/poc-tuya-ble-fingerbot)_
 
 ## Installation
 
@@ -14,7 +14,7 @@ Place the `custom_components` folder in your configuration directory (or add its
 
 ## Usage
 
-After adding to Home Assistan integration should discover all supported Bluetooth devices, or you can add discoverable devices manually.
+After adding to Home Assistant integration should discover all supported Bluetooth devices, or you can add discoverable devices manually.
 
 The integration works locally, but connection to Tuya BLE device requires device ID and encryption key from Tuya IOT cloud. It could be obtained using the same credentials as in official Tuya integration. To obtain the credentials, please refer to official Tuya integration [documentation](https://www.home-assistant.io/integrations/tuya/)
 
@@ -22,8 +22,9 @@ The integration works locally, but connection to Tuya BLE device requires device
 
 * Fingerbots (category_id 'szjqr')
   + Fingerbot (product_id 'yrnk7mnn'), original device, first in category, powered by CR2 battery.
+  + Adaprox Fingerbot (product_id 'y6kttvd6'), built-in battery with USB type C charging.
   + Fingerbot Plus (product_ids 'blliqpsj', 'yiihr7zh'), almost same as original, has sensor button for manual control.
-  + CubeTouch II (product_id 'xhf790if'), bult-in battery with USB type C charging.
+  + CubeTouch II (product_id 'xhf790if'), built-in battery with USB type C charging.
 
   All features available in Home Assistant, except programming (series of actions) - it's not documented and looks useless because it could be implemented by Home Assistant scripts or automations.
 

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -75,10 +75,12 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     TuyaBLEFingerbotModeMapping(dp_id=2),
                 ],
             ),
-            "yrnk7mnn":  # Fingerbot
-            [
-                TuyaBLEFingerbotModeMapping(dp_id=2),
-            ],
+            **dict.fromkeys(
+                ["y6kttvd6", "yrnk7mnn"],  # Fingerbot
+                [
+                    TuyaBLEFingerbotModeMapping(dp_id=2),
+                ],
+            ),
         },
     ),
 }

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -189,16 +189,18 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                     ),
                 )
             ),
-            "yrnk7mnn":  # device product_id
-            TuyaBLEProductInfo(
-                name="Fingerbot",
-                fingerbot=TuyaBLEFingerbotInfo(
-                    switch=2,
-                    mode=8,
-                    up_position=15,
-                    down_position=9,
-                    hold_time=10,
-                    reverse_positions=11,
+            **dict.fromkeys(
+                ["y6kttvd6", "yrnk7mnn"],  # device product_ids
+                TuyaBLEProductInfo(
+                    name="Fingerbot",
+                    fingerbot=TuyaBLEFingerbotInfo(
+                        switch=2,
+                        mode=8,
+                        up_position=15,
+                        down_position=9,
+                        hold_time=10,
+                        reverse_positions=11,
+                    ),
                 ),
             ),
         },

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -175,25 +175,27 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ],
             ),
-            "yrnk7mnn":  # Fingerbot
-            [
-                TuyaBLENumberMapping(
-                    dp_id=9,
-                    description=TuyaBLEDownPositionDescription(),
-                ),
-                TuyaBLENumberMapping(
-                    dp_id=10,
-                    description=TuyaBLEHoldTimeDescription(
-                        native_step=0.1,
+            **dict.fromkeys(
+                ["y6kttvd6", "yrnk7mnn"],  # Fingerbot
+                [
+                    TuyaBLENumberMapping(
+                        dp_id=9,
+                        description=TuyaBLEDownPositionDescription(),
                     ),
-                    coefficient=10.0,
-                    is_available=is_fingerbot_in_push_mode,
-                ),
-                TuyaBLENumberMapping(
-                    dp_id=15,
-                    description=TuyaBLEUpPositionDescription(),
-                ),
-            ],
+                    TuyaBLENumberMapping(
+                        dp_id=10,
+                        description=TuyaBLEHoldTimeDescription(
+                            native_step=0.1,
+                        ),
+                        coefficient=10.0,
+                        is_available=is_fingerbot_in_push_mode,
+                    ),
+                    TuyaBLENumberMapping(
+                        dp_id=15,
+                        description=TuyaBLEUpPositionDescription(),
+                    ),
+                ],
+            ),
         },
     ),
     "wsdcg": TuyaBLECategoryNumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -103,10 +103,12 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     TuyaBLEFingerbotModeMapping(dp_id=8),
                 ],
             ),
-            "yrnk7mnn":  # Fingerbot
-            [
-                TuyaBLEFingerbotModeMapping(dp_id=8),
-            ],
+            **dict.fromkeys(
+                ["y6kttvd6", "yrnk7mnn"],  # Fingerbot
+                [
+                    TuyaBLEFingerbotModeMapping(dp_id=8),
+                ],
+            ),
         },
     ),
 }

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -170,10 +170,12 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     TuyaBLEBatteryMapping(dp_id=12),
                 ],
             ),
-            "yrnk7mnn":  # Fingerbot
-            [
-                TuyaBLEBatteryMapping(dp_id=12),
-            ],
+            **dict.fromkeys(
+                ["y6kttvd6", "yrnk7mnn"],  # Fingerbot
+                [
+                    TuyaBLEBatteryMapping(dp_id=12),
+                ],
+            ),
         },
     ),
     "wsdcg": TuyaBLECategorySensorMapping(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -132,11 +132,13 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     ),
                 ],
             ),
-            "yrnk7mnn":  # Fingerbot
-            [
-                TuyaBLEFingerbotSwitchMapping(dp_id=2),
-                TuyaBLEReversePositionsMapping(dp_id=11),
-            ],
+            **dict.fromkeys(
+                ["y6kttvd6", "yrnk7mnn"],  # Fingerbot
+                [
+                    TuyaBLEFingerbotSwitchMapping(dp_id=2),
+                    TuyaBLEReversePositionsMapping(dp_id=11),
+                ],
+            ),
         },
     ),
     "wsdcg": TuyaBLECategorySwitchMapping(


### PR DESCRIPTION
Just a small bit of copy-paste work really to support the Adaprox branded Fingerbot (non-plus) as well.