### PR TITLE
Support for TCS0533B / STK-02 / tv6peegl Soil Thermo-Hygrometer

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -282,6 +282,9 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "ojzlzzsw": TuyaBLEProductInfo(  # device product_id
                 name="Soil moisture sensor",
             ),
+            "tv6peegl": TuyaBLEProductInfo(  # new device product_id
+                name="Soil Thermo-Hygrometer",
+            ),
         },
     ),
     "znhsb": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -258,6 +258,20 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                 ),
                 TuyaBLEBatteryMapping(dp_id=4),
             ],
+            "tv6peegl": [  # Soil moisture sensor
+                TuyaBLETemperatureMapping(
+                    dp_id=101,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=102,
+                    description=SensorEntityDescription(
+                        key="moisture",
+                        device_class=SensorDeviceClass.MOISTURE,
+                        native_unit_of_measurement=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+            ],
         },
     ),
     "znhsb": TuyaBLECategorySensorMapping(


### PR DESCRIPTION
I stumbled across a cheaper [soil moisture sensor on Amazon](https://www.amazon.com/Diivoo-Moisture-Bluetooth-houseplant-bedrooms/dp/B0BQYJTB8W) and wanted to test it with Home Assistant.

It is a Tuya based product under the Diivoo brand, model # STK-02.

Tuya IoT platform shows it to be `TCS0533B` and the product identifier is tv6peegl

I was able to add the device to the integration, but without this commit the only information I was able to get was the `Signal Strength`

With this commit, I am able to get `Temperature` and `Humidity` from the device. 

I have not attempted the battery or temperature unit fields, as they seem to be configured differently than other devices this configuration handles

## Query Device Details Output
```json
{
  "result": {
    "active_time": 1691553738,
    "category": "wsdcg",
    "create_time": 1691553738,
    "custom_name": "",
    "icon": "smart/icon/ay15662905541765SKtA/5de5e1c4a9e8371f7ae7763d9e4e0bbe.png",
    "id": "{redacted}",
    "ip": "",
    "is_online": false,
    "lat": "",
    "local_key": "{redacted}",
    "lon": "",
    "model": "",
    "name": "Soil Thermo-hygrometer",
    "product_id": "tv6peegl",
    "product_name": "TCS0533B 蓝牙版土壤温湿度传感器",
    "sub": false,
    "time_zone": "-07:00",
    "update_time": 1691553738,
    "uuid": "{redacted}"
  },
  "success": true,
  "t": 1691559227215,
  "tid": "4ff7a2f3367611ee804ade073cb82c5d"
}
```

## Device Control > Query Properties
```json
{
  "result": {
    "properties": [
      {
        "code": "temp_current",
        "custom_name": "",
        "dp_id": 1,
        "time": 1691553738179,
        "value": 0
      },
      {
        "code": "Temp",
        "custom_name": "",
        "dp_id": 101,
        "time": 1691559236022,
        "value": 29
      },
      {
        "code": "Moisure",
        "custom_name": "",
        "dp_id": 102,
        "time": 1691559236954,
        "value": 25
      },
      {
        "code": "battery_status",
        "custom_name": "",
        "dp_id": 117,
        "time": 1691559359926,
        "value": false
      },
      {
        "code": "temp_format",
        "custom_name": "",
        "dp_id": 119,
        "time": 1691558934549,
        "value": "1"
      },
      {
        "code": "temp_count",
        "custom_name": "",
        "dp_id": 122,
        "time": 1691553738179
      },
      {
        "code": "moisure_count",
        "custom_name": "",
        "dp_id": 123,
        "time": 1691553738179
      }
    ]
  },
  "success": true,
  "t": 1691559478675,
  "tid": "e5eb4671367611ee804ade073cb82c5d"
}
```

I'm not sure if it matters, but I have `Control Instruction Mode` set to `DP Instruction`

<img src="https://github.com/PlusPlus-ua/ha_tuya_ble/assets/28514085/88fb51ac-1cee-49b2-8fc1-97eab62bba7d" width=50%>

I quite literally just got this up and going, so haven't been able to test the long term reliability of the connection, but I am getting `Moisture`(humidity), `Temperature`, and `Signal Strength` in Home Assistant now. I also can't attest to the accuracy of this sensor, it seems accurate enough to work but not sure how it compares to other plant sensors on the market.

<img src="https://github.com/PlusPlus-ua/ha_tuya_ble/assets/28514085/14c602f3-4531-40ea-9ae6-100dd20b9f44" width=50%>
